### PR TITLE
Xdebug edits

### DIFF
--- a/develop
+++ b/develop
@@ -5,8 +5,10 @@ trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP
 # Mac: Get host address
 STEP="Setting XDEBUG_HOST to hostmachine IP"
 #export XDEBUG_HOST=$(ip route | awk '/docker0/ { print $9 }')
-export XDEBUG_HOST=${XDEBUG_HOST:-(ip route | awk '/eth1/ { print $9 }')}
+#export XDEBUG_HOST=${XDEBUG_HOST:-(ip route | awk '/eth1/ { print $9 }')}
 #export XDEBUG_HOST=$(ip -o -4 addr list ${MY_NETWORK_INTERFACE:-eth0} | awk '{print $4}' | cut -d/ -f1)
+[[ $XDEBUG_HOST ]] || XDEBUG_HOST=$(ip route | awk '/eth1/ { print $9 }')
+export XDEBUG_HOST
 
 #export XDEBUG_HOST=192.168.99.1
 

--- a/develop
+++ b/develop
@@ -4,13 +4,8 @@ trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP
 
 # Mac: Get host address
 STEP="Setting XDEBUG_HOST to hostmachine IP"
-#export XDEBUG_HOST=$(ip route | awk '/docker0/ { print $9 }')
-#export XDEBUG_HOST=${XDEBUG_HOST:-(ip route | awk '/eth1/ { print $9 }')}
-#export XDEBUG_HOST=$(ip -o -4 addr list ${MY_NETWORK_INTERFACE:-eth0} | awk '{print $4}' | cut -d/ -f1)
-[[ $XDEBUG_HOST ]] || XDEBUG_HOST=$(ip route | awk '/eth1/ { print $9 }')
+[[ $XDEBUG_HOST ]] || XDEBUG_HOST=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
 export XDEBUG_HOST
-
-#export XDEBUG_HOST=192.168.99.1
 
 echo "setup host address to: $XDEBUG_HOST"
 

--- a/develop
+++ b/develop
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
+trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
 
 
 # Mac: Get host address
-export XDEBUG_HOST=$(ipconfig getifaddr en1)
+STEP="Setting XDEBUG_HOST to hostmachine IP"
+#export XDEBUG_HOST=$(ip route | awk '/docker0/ { print $9 }')
+#export XDEBUG_HOST=$(ip route | awk '/eth1/ { print $9 }')
+export XDEBUG_HOST=$(ip -o -4 addr list ${MY_NETWORK_INTERFACE:-eth0} | awk '{print $4}' | cut -d/ -f1)
+echo "setup host address to: $XDEBUG_HOST"
 
 # Linux: Get host address
 # Via: http://stackoverflow.com/questions/13322485/how-to-i-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x
 #export XDEBUG_HOST=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | head -n1)
 
 # Other env variables
+STEP="Setting ENV variables"
 export APP_ENV=${APP_ENV:-local}
 export APP_PORT=${APP_PORT:-80}
 export DB_PORT=${DB_PORT:-3306}
@@ -32,6 +38,7 @@ COMPOSE="docker-compose -f docker-compose.$COMPOSE_FILE.yml"
 
 if [ $# -gt 0 ];then
     if [ "$1" == "art" ]; then
+		STEP="Running artisan command"
         shift 1
         $COMPOSE run --rm $TTY \
             -w /var/www/html \
@@ -40,6 +47,7 @@ if [ $# -gt 0 ];then
     # If "composer" is used, pass-thru to "composer"
     # inside a new container
     elif [ "$1" == "composer" ]; then
+		STEP="Running composer command"
         shift 1
         $COMPOSE run --rm $TTY \
             -w /var/www/html \
@@ -49,6 +57,7 @@ if [ $# -gt 0 ];then
     # If "test" is used, run unit tests,
     # pass-thru any extra arguments to php-unit
     elif [ "$1" == "test" ]; then
+		STEP="Running phpunit command in new app container"
         shift 1
         $COMPOSE run --rm $TTY \
             -w /var/www/html \
@@ -56,6 +65,7 @@ if [ $# -gt 0 ];then
             ./vendor/bin/phpunit "$@"
 
     elif [ "$1" == "t" ]; then
+		STEP="Running phpunit command in existing app container"
 		shift 1
 		$COMPOSE exec \
 			app \
@@ -64,6 +74,7 @@ if [ $# -gt 0 ];then
     # If "npm" is used, run npm
     # from our node container
     elif [ "$1" == "npm" ]; then
+		STEP="Running npm command"
         shift 1
         $COMPOSE run --rm $TTY \
             -w /var/www/html \
@@ -73,12 +84,14 @@ if [ $# -gt 0 ];then
     # If "gulp" is used, run gulp
     # from our node container
     elif [ "$1" == "gulp" ]; then
+		STEP="Running gulp command"
         shift 1
         $COMPOSE run --rm $TTY \
             -w /var/www/html \
             node \
             ./node_modules/.bin/gulp "$@"
     else
+		STEP="Running any override docker command"
         $COMPOSE "$@"
     fi
 else

--- a/develop
+++ b/develop
@@ -5,8 +5,11 @@ trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP
 # Mac: Get host address
 STEP="Setting XDEBUG_HOST to hostmachine IP"
 #export XDEBUG_HOST=$(ip route | awk '/docker0/ { print $9 }')
-#export XDEBUG_HOST=$(ip route | awk '/eth1/ { print $9 }')
-export XDEBUG_HOST=$(ip -o -4 addr list ${MY_NETWORK_INTERFACE:-eth0} | awk '{print $4}' | cut -d/ -f1)
+export XDEBUG_HOST=${XDEBUG_HOST:-(ip route | awk '/eth1/ { print $9 }')}
+#export XDEBUG_HOST=$(ip -o -4 addr list ${MY_NETWORK_INTERFACE:-eth0} | awk '{print $4}' | cut -d/ -f1)
+
+#export XDEBUG_HOST=192.168.99.1
+
 echo "setup host address to: $XDEBUG_HOST"
 
 # Linux: Get host address

--- a/docker/app/start-container
+++ b/docker/app/start-container
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
+trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
+
 if [ ! "production" == "$APP_ENV" ] && [ ! "prod" == "$APP_ENV" ]; then
     # Enable xdebug
+    STEP="setting XDEBUG in container"
+
+	touch /var/log/xdebug.log
+    ln -sf /dev/stdout /var/log/xdebug.log
 
     ## FPM
     ln -sf /etc/php/7.0/mods-available/xdebug.ini /etc/php/7.0/fpm/conf.d/20-xdebug.ini
@@ -10,6 +16,7 @@ if [ ! "production" == "$APP_ENV" ] && [ ! "prod" == "$APP_ENV" ]; then
     ln -sf /etc/php/7.0/mods-available/xdebug.ini /etc/php/7.0/cli/conf.d/20-xdebug.ini
 else
     # Disable xdebug
+    STEP="disabling XDEBUG"
 
     ## FPM
     if [ -e /etc/php/7.0/fpm/conf.d/20-xdebug.ini ]; then

--- a/docker/app/start-container
+++ b/docker/app/start-container
@@ -7,7 +7,8 @@ if [ ! "production" == "$APP_ENV" ] && [ ! "prod" == "$APP_ENV" ]; then
     STEP="setting XDEBUG in container"
 
 	touch /var/log/xdebug.log
-    ln -sf /dev/stdout /var/log/xdebug.log
+	chmod 777 /var/log/xdebug.log
+#    ln -sf /dev/stdout /var/log/xdebug.log
 
     ## FPM
     ln -sf /etc/php/7.0/mods-available/xdebug.ini /etc/php/7.0/fpm/conf.d/20-xdebug.ini

--- a/docker/app/xdebug.ini
+++ b/docker/app/xdebug.ini
@@ -4,5 +4,10 @@ xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=0
+xdebug.cli_color=0
+xdebug.profiler_enable=0
+xdebug.remote_mode=req
 xdebug.idekey=docker
 xdebug.remote_host=192.168.1.2
+xdebug.remote_log=/var/log/xdebug.log
+


### PR DESCRIPTION
Here are some basic edits to enable xdebug debugging.

Key takeaway for Windows 7 users running boot2docker should do the following:

1.  In the boot2docker VM, run the command: `export XDEBUG_HOST=192.168.99.1; ./develop up -d`

2.  Remember for Windows 7 users, you need to find the correct network bridge adapter.  When you start the boot2docker enviornment you will see:

```


                        ##         .
                  ## ## ##        ==
               ## ## ## ## ##    ===
           /"""""""""""""""""\___/ ===
      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
           \______ o           __/
             \    \         __/
              \____\_______/

docker is configured to use the default machine with IP 192.168.99.100
```

Therefore, your IP address will be `192.168.99.1`