### PR TITLE
Add locales package to Dockerfile

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:16.04
 
 MAINTAINER Chris Fidao
 
-RUN locale-gen en_US.UTF-8
+RUN apt-get update \
+    && apt-get install -y locales \
+    && locale-gen en_US.UTF-8
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
It's a problem i've seen in every videos of the shippingdocker.com course : we need to install the `locales` packages in order to use `locale-gen`

You may want to add a warning on somes videos about it...